### PR TITLE
Fix aria-labelledby on create/edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add filtering conditions for create/edit set. Refs UIOAIPMH-6.
 * Update react-intl to ^5.7.0. Refs UIOAIPMH-20.
 * Add set list. Refs UIOAIPMH-9.
+* Fix aria-labelledby on create/edit page. Refs UIOAIPMH-27.
 
 ## [1.2.0](https://github.com/folio-org/ui-oai-pmh/tree/v1.2.0) (2020-07-03)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v1.1.0...v1.2.0)

--- a/src/settings/components/common/SaveButtonTooltipWrapper.js
+++ b/src/settings/components/common/SaveButtonTooltipWrapper.js
@@ -23,7 +23,7 @@ class SaveButton extends React.Component {
       showTooltip,
       children,
     } = this.props;
-    const ariaLabelledby = showTooltip ? { 'aria-labelledby': 'save-button-tooltip-tex' } : {};
+    const ariaLabelledby = showTooltip ? { 'aria-labelledby': 'save-button-tooltip-text' } : {};
 
     return (
       <>


### PR DESCRIPTION
# Purpose
Fix aria-labelledby for "Save & close" on create/edit page
# Link
https://issues.folio.org/browse/UIOAIPMH-27