### PR TITLE
UIOAIPMH-29: Consume FormattedDate and FormattedTime via stripes-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-oai-pmh
 
+## 1.3.2 (IN PROGRESS)
+*  Consume `FormattedDate` and `FormattedTime` via `stripes-components`. Refs UIOAIPMH-29.
+
 ## [1.3.1](https://github.com/folio-org/ui-oai-pmh/tree/v1.3.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v1.3.0...v1.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-oai-pmh
 
-## 1.3.2 (IN PROGRESS)
+## 1.4.0 (IN PROGRESS)
 *  Consume `FormattedDate` and `FormattedTime` via `stripes-components`. Refs UIOAIPMH-29.
 
 ## [1.3.1](https://github.com/folio-org/ui-oai-pmh/tree/v1.3.1) (2020-10-15)

--- a/src/settings/components/Sets/SetsList/SetsList.js
+++ b/src/settings/components/Sets/SetsList/SetsList.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormattedDate,
-  FormattedMessage,
-  FormattedTime,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   MultiColumnList,
   Pane,
   Paneset,
+  FormattedTime,
+  FormattedDate,
 } from '@folio/stripes/components';
+
 
 import LastMenu from './components';
 import {

--- a/src/settings/components/Sets/SetsList/SetsList.js
+++ b/src/settings/components/Sets/SetsList/SetsList.js
@@ -10,7 +10,6 @@ import {
   FormattedDate,
 } from '@folio/stripes/components';
 
-
 import LastMenu from './components';
 import {
   FILL_PANE_WIDTH,


### PR DESCRIPTION
[[UIOAPMH-29]](https://issues.folio.org/browse/UIOAIPMH-29)

## Purpose 
Consume `FormattedDate `and `FormattedTime` via `stripes-components` instead of `react-intl` in order to have the value prop automatically reformatted into a compliant string.