### PR TITLE
UIOAIPMH-38: Update `stripes-cli` to `v2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0 (IN PROGRESS)
 * Consume `FormattedDate` and `FormattedTime` via `stripes-components`. Refs UIOAIPMH-29.
 * Update `stripes` to `v6.0.0`. Refs UIOAIPMH-35.
+* Update `stripes-cli` to `v2.0.0`. UIOAIPMH-38.
 
 ## [1.3.1](https://github.com/folio-org/ui-oai-pmh/tree/v1.3.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v1.3.0...v1.3.1)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-components": "^9.0.0",
     "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^9.0.0",


### PR DESCRIPTION
## Purpose

Update `stripes-cli` to `v2.0.0` in the scope of the [UIOAIPMH-38](https://issues.folio.org/browse/UIOAIPMH-38).