### PR TITLE
UIOAIPMH-39: Update the UI permission names for current OAI-PMH permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Consume `FormattedDate` and `FormattedTime` via `stripes-components`. Refs UIOAIPMH-29.
 * Update `stripes` to `v6.0.0`. Refs UIOAIPMH-35.
 * Update `stripes-cli` to `v2.0.0`. UIOAIPMH-38.
+* Update the UI permission names for current OAI-PMH permissions. UIOAIPMH-39.
 
 ## [1.3.1](https://github.com/folio-org/ui-oai-pmh/tree/v1.3.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v1.3.0...v1.3.1)

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       },
       {
         "permissionName": "ui-oai-pmh.view",
-        "displayName": "Settings (OAI-PMH): Display list of settings pages",
+        "displayName": "Settings (OAI-PMH): Can view",
         "subPermissions": [
           "settings.oai-pmh.enabled",
           "configuration.entries.collection.get",

--- a/translations/ui-oai-pmh/en.json
+++ b/translations/ui-oai-pmh/en.json
@@ -1,6 +1,6 @@
 {
   "meta.title": "OAI-PMH",
-  "permission.view": "Settings (OAI-PMH): Display list of settings pages",
+  "permission.view": "Settings (OAI-PMH): Can view",
   "permission.edit": "Settings (OAI-PMH): Can view and edit settings",
 
   "settings.title": "OAI-PMH",


### PR DESCRIPTION
## Purpose

Update the UI permission names for current OAI-PMH permissions in the scope of the [UIOAIPMH-39](https://issues.folio.org/browse/UIOAIPMH-39).