### PR TITLE
UIOAIPMH-63 Upgrade react-redux to v8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,26 @@
 
 ## (4.0.0) IN PROGRESS
 
-* [UIOAIPMH-22](https://issues.folio.org/browse/UIOAIPMH-22) Expand OAI-PMH Behavior settings with Records Source parameter
-* Upgrade `react-redux` to `v8`. Upgrade `stripes` to `v8`. Refs UIOAIPMH-63.
+[UIOAIPMH-22](https://issues.folio.org/browse/UIOAIPMH-22) Expand OAI-PMH Behavior settings with Records Source parameter
+[UIOAIPMH-63](https://issues.folio.org/browse/UIOAIPMH-63) Upgrade `react-redux` to `v8`. Upgrade `stripes` to `v8`.
 
 ## [3.3.0] (https://github.com/folio-org/ui-oai-pmh/tree/v3.3.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.2.2...v3.3.0)
 
-* [UIOAIPMH-56](https://issues.folio.org/browse/UIOAIPMH-56) components are incorrectly imported directly from stripes-*packages
-* [UIOAIPMH-60](https://issues.folio.org/browse/UIOAIPMH-60) core-js is incorrectly listed as a peer-dependency
+[UIOAIPMH-56](https://issues.folio.org/browse/UIOAIPMH-56) components are incorrectly imported directly from stripes-*packages
+[UIOAIPMH-60](https://issues.folio.org/browse/UIOAIPMH-60) core-js is incorrectly listed as a peer-dependency
 
 ## [3.2.2] (https://github.com/folio-org/ui-oai-pmh/tree/v3.2.2) (2022-08-03)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.2.1...v3.2.2)
 
-* [UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Revert Set default settings for OAI-PMH in FOLIO.
+[UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Revert Set default settings for OAI-PMH in FOLIO.
 
 ## [3.2.1] (https://github.com/folio-org/ui-oai-pmh/tree/v3.2.1) (2022-07-22)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.2.0...v3.2.1)
 
-* [UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Set default settings for OAI-PMH in FOLIO.
-* [UIOAIPMH-52](https://issues.folio.org/browse/UIOAIPMH-52) replace babel-eslint with @babel/eslint-parser
-* [UIOAIPMH-51](https://issues.folio.org/browse/UIOAIPMH-51) Remove react-hot-loader from package.json
+[UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Set default settings for OAI-PMH in FOLIO.
+[UIOAIPMH-52](https://issues.folio.org/browse/UIOAIPMH-52) replace babel-eslint with @babel/eslint-parser
+[UIOAIPMH-51](https://issues.folio.org/browse/UIOAIPMH-51) Remove react-hot-loader from package.json
 
 ## [3.2.0] (https://github.com/folio-org/ui-oai-pmh/tree/v3.2.0) (2022-07-07)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.1.0...v3.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,27 @@
 # Change history for ui-oai-pmh
 
-## IN PROGRESS
+## (4.0.0) IN PROGRESS
 
-[UIOAIPMH-22](https://issues.folio.org/browse/UIOAIPMH-22) Expand OAI-PMH Behavior settings with Records Source parameter
+* [UIOAIPMH-22](https://issues.folio.org/browse/UIOAIPMH-22) Expand OAI-PMH Behavior settings with Records Source parameter
+* Upgrade `react-redux` to `v8`. Upgrade `stripes` to `v8`. Refs UIOAIPMH-63.
 
 ## [3.3.0] (https://github.com/folio-org/ui-oai-pmh/tree/v3.3.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.2.2...v3.3.0)
 
-[UIOAIPMH-56](https://issues.folio.org/browse/UIOAIPMH-56) components are incorrectly imported directly from stripes-*packages
-[UIOAIPMH-60](https://issues.folio.org/browse/UIOAIPMH-60) core-js is incorrectly listed as a peer-dependency
+* [UIOAIPMH-56](https://issues.folio.org/browse/UIOAIPMH-56) components are incorrectly imported directly from stripes-*packages
+* [UIOAIPMH-60](https://issues.folio.org/browse/UIOAIPMH-60) core-js is incorrectly listed as a peer-dependency
 
 ## [3.2.2] (https://github.com/folio-org/ui-oai-pmh/tree/v3.2.2) (2022-08-03)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.2.1...v3.2.2)
 
-[UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Revert Set default settings for OAI-PMH in FOLIO.
+* [UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Revert Set default settings for OAI-PMH in FOLIO.
 
 ## [3.2.1] (https://github.com/folio-org/ui-oai-pmh/tree/v3.2.1) (2022-07-22)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.2.0...v3.2.1)
 
-[UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Set default settings for OAI-PMH in FOLIO.
-[UIOAIPMH-52](https://issues.folio.org/browse/UIOAIPMH-52) replace babel-eslint with @babel/eslint-parser
-[UIOAIPMH-51](https://issues.folio.org/browse/UIOAIPMH-51) Remove react-hot-loader from package.json
+* [UIOAIPMH-53](https://issues.folio.org/browse/UIOAIPMH-53) Set default settings for OAI-PMH in FOLIO.
+* [UIOAIPMH-52](https://issues.folio.org/browse/UIOAIPMH-52) replace babel-eslint with @babel/eslint-parser
+* [UIOAIPMH-51](https://issues.folio.org/browse/UIOAIPMH-51) Remove react-hot-loader from package.json
 
 ## [3.2.0] (https://github.com/folio-org/ui-oai-pmh/tree/v3.2.0) (2022-07-07)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/oai-pmh",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "OAI-PMH manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-oai-pmh",
@@ -9,7 +9,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "stripes serve",
@@ -24,11 +24,11 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@bigtest/interactor": "^0.8.1",
     "@babel/eslint-parser": "^7.18.2",
-    "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/eslint-config-stripes": "^6.1.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.0.0",
-    "@folio/stripes-components": "^10.0.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "@formatjs/cli": "^4.8.2",
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.4",
@@ -50,7 +50,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "5.7.0",
-    "react-redux": "^7.2.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
@@ -64,10 +64,11 @@
     "react-router-prop-types": "^1.0.4"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0"
   },
   "stripes": {


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UIOAIPMH-63.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.