### PR TITLE
UIOAIPMH-65: Avoid private paths in stripes-core imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 
+[UIOAIPMH-65](https://issues.folio.org/browse/UIOAIPMH-65) Avoid private paths in stripes-core imports.
 
 ## [4.0.0] (https://github.com/folio-org/ui-oai-pmh/tree/v4.0.0) (2023-02-21)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.3.0...v4.0.0)

--- a/src/settings/components/Sets/SetsList/SetLits.test.js
+++ b/src/settings/components/Sets/SetsList/SetLits.test.js
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 
 import '../../../../../test/jest/__mock__';
 
-import { StripesContext } from '@folio/stripes-core/src/StripesContext';
+import { StripesContext } from '@folio/stripes/core';
 import { renderWithRouter } from '../../../../../test/jest/helpers';
 import SetsList from './SetsList';
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIOAIPMH-65

Avoid private paths in stripes-core imports.