### PR TITLE
UIOAIPMH-72: prefer @folio/stripes exports to private paths when importing components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 [UIOAIPMH-69](https://issues.folio.org/browse/UIOAIPMH-69) *BREAKING* Update `react` to `v18`.
 [UIOAIPMH-71](https://issues.folio.org/browse/UIOAIPMH-71) OAI-PMH settings: Ensure your settings HTML page title follow this format - <<App name>> settings - <<selected page name>> - FOLIO
 [UIOAIPMH-75](https://issues.folio.org/browse/UIOAIPMH-75) *BREAKING* bump `react-intl` to `v6.4.4`.
+[UIOAIPMH-72](https://issues.folio.org/browse/UIOAIPMH-72) prefer @folio/stripes exports to private paths when importing components.
 
 ## [4.0.0] (https://github.com/folio-org/ui-oai-pmh/tree/v4.0.0) (2023-02-21)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v3.3.0...v4.0.0)

--- a/src/settings/hooks/useLogs.js
+++ b/src/settings/hooks/useLogs.js
@@ -1,4 +1,4 @@
-import { useOkapiKy } from '@folio/stripes-core';
+import { useOkapiKy } from '@folio/stripes/core';
 import { useQuery } from 'react-query';
 
 export const useLogs = () => {


### PR DESCRIPTION
prefer @folio/stripes exports to private paths when importing components

[UIOAIPMH-72](https://issues.folio.org/browse/UIOAIPMH-72)