### PR TITLE
UIOAIPMH-77 User with view only permissions can edit OAI-PMH settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-oai-pmh
 
 ## IN PROGRESS
+[UIOAIPMH-77](https://issues.folio.org/browse/UIOAIPMH-77) User with view only permissions can edit OAI-PMH settings
 
 ## [5.0.0] (https://github.com/folio-org/ui-oai-pmh/tree/v5.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v4.0.0...v5.0.0)

--- a/src/settings/components/common/RowComponent.js
+++ b/src/settings/components/common/RowComponent.js
@@ -12,8 +12,9 @@ import {
   Row,
   Tooltip,
 } from '@folio/stripes/components';
+import { withStripes } from '@folio/stripes/core';
 
-export default class RowComponent extends Component {
+class RowComponent extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
@@ -21,6 +22,9 @@ export default class RowComponent extends Component {
     // Additional options for select box
     dataOptions: PropTypes.arrayOf(PropTypes.object),
     component: PropTypes.node.isRequired,
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   static defaultProps = {
@@ -38,7 +42,9 @@ export default class RowComponent extends Component {
       id,
       label,
       tooltip,
+      stripes,
     } = this.props;
+    const hasEditPerm = stripes.hasPerm('ui-oai-pmh.edit');
     const fieldPropsAttributeNames = ['id', 'required', 'type', 'component', 'dataOptions'];
     const fieldProps = pick(this.props, fieldPropsAttributeNames);
     const dataTest = omit(this.props, [...fieldPropsAttributeNames, 'label', 'tooltip']);
@@ -57,6 +63,7 @@ export default class RowComponent extends Component {
               {...fieldProps}
               name={id}
               label={<FormattedMessage id={label} />}
+              disabled={!hasEditPerm}
             />
           </div>
           {tooltip &&
@@ -72,3 +79,5 @@ export default class RowComponent extends Component {
     );
   }
 }
+
+export default withStripes(RowComponent);


### PR DESCRIPTION
After this PR merged, all fields will be disabled if there aren't edit permissions. Refs [UIOAIPMH-77](https://issues.folio.org/browse/UIOAIPMH-77)

![image](https://github.com/folio-org/ui-oai-pmh/assets/86330150/1edcd412-7707-4d51-a4e3-a875ebf84088)

![image](https://github.com/folio-org/ui-oai-pmh/assets/86330150/ae053d4f-1bf7-41c3-a11f-9716f4feb034)

![image](https://github.com/folio-org/ui-oai-pmh/assets/86330150/b41f893d-453a-49f1-8963-bf54a6f2876c)

