### PR TITLE
UIOAIPMH-79 Make downloading log files consistent with data export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+[UIOAIPMH-79](https://issues.folio.org/browse/UIOAIPMH-79) Make downloading log files consistent with data export.
+
 ## [5.1.0] (https://github.com/folio-org/ui-oai-pmh/tree/v5.0.0) (2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v5.0.0...v5.1.0)
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^5.1.0",
+    "file-saver": "^2.0.5",
     "lodash": "^4.17.15",
     "moment": "^2.29.4",
     "prop-types": "^15.6.0",

--- a/src/settings/components/Logs/components/LinkToErrorFile.js
+++ b/src/settings/components/Logs/components/LinkToErrorFile.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { saveAs } from 'file-saver';
+
+import { Button, Icon } from '@folio/stripes/components';
+
+import { useFileDownload } from '../../../hooks/useFileDownload';
+
+export const LinkToErrorFile = ({ linkToErrorFile, requestId }) => {
+  const { refetch } = useFileDownload({
+    id: requestId,
+    onSuccess: data => {
+      saveAs(new Blob([data]), linkToErrorFile);
+    },
+  });
+
+  return linkToErrorFile && (
+    <Button onClick={refetch} marginBottom0>
+      <Icon
+        icon="download"
+        iconPosition="end"
+      >
+        <FormattedMessage id="ui-oai-pmh.settings.logs.download" />
+      </Icon>
+    </Button>
+  );
+};
+
+LinkToErrorFile.propTypes = {
+  linkToErrorFile: PropTypes.string,
+  requestId: PropTypes.string,
+};

--- a/src/settings/hooks/useFileDownload.js
+++ b/src/settings/hooks/useFileDownload.js
@@ -1,0 +1,24 @@
+import { useQuery } from 'react-query';
+import { useOkapiKy } from '@folio/stripes/core';
+
+export const QUERY_KEY_DOWNLOAD_LOGS = 'QUERY_KEY_DOWNLOAD_LOGS';
+
+export const useFileDownload = ({
+  id,
+  onSuccess,
+  onSettled,
+}) => {
+  const ky = useOkapiKy();
+
+  const { refetch } = useQuery(
+    {
+      queryKey: [QUERY_KEY_DOWNLOAD_LOGS, id],
+      queryFn: () => ky.get(`oai/request-metadata/${id}/logs`).blob(),
+      enabled: false,
+      onSuccess,
+      onSettled
+    },
+  );
+
+  return { refetch };
+};

--- a/src/settings/util/formatters.js
+++ b/src/settings/util/formatters.js
@@ -1,16 +1,11 @@
-import {
-  FolioFormattedTime,
-} from '@folio/stripes-acq-components';
 import React from 'react';
-import { TextLink } from '@folio/stripes/components';
-import { FormattedMessage } from 'react-intl';
+
+import { FolioFormattedTime } from '@folio/stripes-acq-components';
+
+import { LinkToErrorFile } from '../components/Logs/components/LinkToErrorFile';
 
 export const logsFormatter = {
   startedDate: ({ startedDate }) => <FolioFormattedTime dateString={startedDate} />,
   lastUpdatedDate: ({ lastUpdatedDate }) => <FolioFormattedTime dateString={lastUpdatedDate} />,
-  linkToErrorFile: ({ linkToErrorFile }) => linkToErrorFile && (
-    <TextLink href={linkToErrorFile}>
-      <FormattedMessage id="ui-oai-pmh.settings.logs.download" />
-    </TextLink>
-  )
+  linkToErrorFile: ({ linkToErrorFile, requestId }) => <LinkToErrorFile linkToErrorFile={linkToErrorFile} requestId={requestId} />,
 };


### PR DESCRIPTION
After this PR merged, it will be possible to download logs files using new endpoint (previously it was link with download attribute). Refs: [UIOAIPMH-79](https://folio-org.atlassian.net/browse/UIOAIPMH-79)

![image](https://github.com/folio-org/ui-oai-pmh/assets/86330150/d10a3da7-c172-4db5-992f-836eae37fb2f)
