### PR TITLE
UIOAIPMH-79 Add missed permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
         "displayName": "Settings (OAI-PMH): Can view logs",
         "subPermissions": [
           "ui-oai-pmh.view",
-          "oai-pmh.request-metadata.collection.get"
+          "oai-pmh.request-metadata.collection.get",
+          "oai-pmh.request-metadata.logs.item.get"
         ],
         "visible": true
       }


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-oai-pmh/pull/200 permission was missed. 
Note: changelog was updated in initial story