### PR TITLE
UIOAIPMH-83 React v19: refactor away from default props for functional components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 [UIOAIPMH-79](https://issues.folio.org/browse/UIOAIPMH-79) Make downloading log files consistent with data export.
 [UIOAIPMH-82](https://issues.folio.org/browse/UIOAIPMH-82) Remove local QueryClientProvider from ui-oai-pmh.
+[UIOAIPMH-83](https://issues.folio.org/browse/UIOAIPMH-83) React v19: refactor away from default props for functional components.
 
 ## [5.1.0] (https://github.com/folio-org/ui-oai-pmh/tree/v5.0.0) (2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v5.0.0...v5.1.0)

--- a/src/settings/components/Sets/SetsForm/SetsForm.js
+++ b/src/settings/components/Sets/SetsForm/SetsForm.js
@@ -31,13 +31,13 @@ import {
 import css from './SetsForm.css';
 
 const SetsForm = ({
+  metadata = null,
   pristine,
   submitting,
   handleSubmit,
   stripes,
   form,
   formTitle,
-  metadata,
   onBack,
   filteringConditionsDataOptions,
 }) => {
@@ -112,10 +112,6 @@ SetsForm.propTypes = {
   metadata: PropTypes.object,
   filteringConditionsDataOptions: PropTypes.object.isRequired,
   onBack: PropTypes.func.isRequired,
-};
-
-SetsForm.defaultProps = {
-  metadata: null
 };
 
 export default stripesFinalForm({

--- a/src/settings/components/Sets/SetsForm/components/GeneralInformation/components/SetSpecification/SetSpecification.js
+++ b/src/settings/components/Sets/SetsForm/components/GeneralInformation/components/SetSpecification/SetSpecification.js
@@ -21,7 +21,7 @@ const generateSetSpecification = (value) => (
 const SetSpecification = ({
   label,
   input: {
-    value,
+    value = [],
   },
 }) => {
   return (
@@ -40,12 +40,6 @@ const SetSpecification = ({
       </div>
     </>
   );
-};
-
-SetSpecification.defaultProps = {
-  input: {
-    values: [],
-  },
 };
 
 SetSpecification.propTypes = {

--- a/src/settings/components/Sets/SetsList/SetsList.js
+++ b/src/settings/components/Sets/SetsList/SetsList.js
@@ -44,9 +44,9 @@ const resultsFormatter = () => ({
 });
 
 const SetsList = ({
-  isLoading,
-  totalCount,
-  sets,
+  isLoading = false,
+  totalCount = 0,
+  sets = [],
   onRowClick,
   onNeedMoreData,
   children,
@@ -88,12 +88,6 @@ SetsList.propTypes = {
   onRowClick: PropTypes.func.isRequired,
   onNeedMoreData: PropTypes.func.isRequired,
   children: PropTypes.node,
-};
-
-SetsList.defaultProps = {
-  isLoading: false,
-  totalCount: 0,
-  sets: [],
 };
 
 export default SetsList;

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -6,4 +6,5 @@ import './stripesComponents.mock';
 import './currencyData.mock';
 import './reactIntl.mock';
 import './resizeObserver.mock';
+import './stripesProfilePicture.mock';
 

--- a/test/jest/__mock__/stripesProfilePicture.mock.js
+++ b/test/jest/__mock__/stripesProfilePicture.mock.js
@@ -1,0 +1,1 @@
+jest.mock('@folio/stripes-smart-components/lib/ProfilePicture', () => ({ default: 'span' }));


### PR DESCRIPTION
After this PR merged all default props for functional components will be repalced with new syntax. Refs [UIOAIPMH-83](https://folio-org.atlassian.net/browse/UIOAIPMH-83)