### PR TITLE
UIOAIPMH-102 Prior to displaying actual OAI-PMH settings disabled settings are displayed for a moment

### DIFF
--- a/src/settings/components/General/components/GeneralForm.js
+++ b/src/settings/components/General/components/GeneralForm.js
@@ -47,7 +47,7 @@ const GeneralForm = ({
 }) => {
   const stripes = useStripes();
 
-  const isOaiServiceSavedAsEnabled = !!initialValues?.enableOaiService;
+  const isOaiServiceSavedAsEnabled = initialValues?.enableOaiService;
   const fieldDisabled = !isOaiServiceSavedAsEnabled;
   const disabledTooltipId = getTooltip(fieldDisabled, 'ui-oai-pmh.settings.general.tooltip.fieldDisabled');
   const formatter = value => (isOaiServiceSavedAsEnabled ? value : '');

--- a/src/settings/components/General/components/GeneralForm.test.js
+++ b/src/settings/components/General/components/GeneralForm.test.js
@@ -88,6 +88,23 @@ describe('General form', () => {
     });
   });
 
+  describe('when initialValues are not provided and config indicates service is enabled', () => {
+    beforeEach(() => {
+      useConfiguration.mockReturnValue({
+        config: {
+          configValue: { enableOaiService: true },
+        },
+        isConfigsLoading: false,
+      });
+    });
+
+    it('should not render oai notification', () => {
+      renderGeneralForm();
+
+      expect(screen.queryByTestId('oai-notification')).not.toBeInTheDocument();
+    });
+  });
+
   describe('when OAI service is enabled', () => {
     beforeEach(() => {
       useConfiguration.mockReturnValue({

--- a/src/settings/components/common/OaiNotification/OaiNotification.js
+++ b/src/settings/components/common/OaiNotification/OaiNotification.js
@@ -12,11 +12,11 @@ import css from './OaiNotification.css';
 const boldTag = (chunks) => <b>{chunks}</b>;
 
 const OaiNotification = ({ isGeneral = false, isOaiServiceEnabled: isOaiServiceEnabledProp }) => {
-  const { config } = useConfiguration(GENERAL_CONFIG_NAME);
+  const { config, isConfigsLoading } = useConfiguration(GENERAL_CONFIG_NAME);
 
   const isEnabled = isOaiServiceEnabledProp ?? config?.configValue?.enableOaiService;
 
-  if (isEnabled) return null;
+  if (isConfigsLoading || isEnabled) return null;
 
   const messageId = isGeneral
     ? 'ui-oai-pmh.settings.general.oaiServiceIsDisabled'


### PR DESCRIPTION
 The "OAI service disabled" banner was briefly visible on page load even when the service was enabled. Two issues caused this:                                                                                        
  1. `OaiNotification` rendered before config finished loading — there was no loading guard, so it defaulted to showing the "disabled" state during the fetch                                                          
  2. `GeneralForm` coerced `initialValues?.enableOaiService` with `!!`, turning `undefined` into `false`. This was passed as `false` to `OaiNotification`, which blocked the `??` fallback to config and forced the    
  banner to show regardless of the actual config value                                                                                                                                                                 
   
  ### Changes                                                                                                                                                                                                          
  - **`OaiNotification`**: return `null` while `isConfigsLoading` is true to prevent the "service disabled" banner from flashing before config data arrives
  - **`GeneralForm`**: removed `!!` coercion on `initialValues?.enableOaiService` so that when no saved value exists, `OaiNotification` correctly falls back to the config state via `??` instead of always receiving
  `false`

Refs:  [UIOAIPMH-102](https://folio-org.atlassian.net/browse/UIOAIPMH-102)