### PR TITLE
UIOAIPMH-98 Fix error when switch affiliation from OAI-PMH Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+[UIOAIPMH-98](https://folio-org.atlassian.net/browse/UIOAIPMH-98) Fix error when switch affiliation from OAI-PMH Settings page
+
 ## [7.0.0] (https://github.com/folio-org/ui-oai-pmh/tree/v6.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-oai-pmh/compare/v6.0.0...v7.0.0)
 

--- a/src/settings/hooks/useConfiguration.js
+++ b/src/settings/hooks/useConfiguration.js
@@ -19,7 +19,11 @@ export const useConfiguration = (name) => {
     queryKey: [namespaceKey, name],
     queryFn: () => ky.get('oai-pmh/configuration-settings', { searchParams: { name } }).json(),
     enabled: !!name,
-    onError: () => {
+    refetchOnWindowFocus: false,
+    onError: (error) => {
+      // AbortError means the request was cancelled
+      if (error?.name === 'AbortError') return;
+
       showCallout({
         type: CALLOUT_ERROR_TYPE,
         message: formatMessage({ id: 'ui-oai-pmh.error.sww' }),

--- a/src/settings/hooks/useConfiguration.test.js
+++ b/src/settings/hooks/useConfiguration.test.js
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useQuery } from 'react-query';
 
 import { useOkapiKy, useNamespace } from '@folio/stripes/core';
+import { useShowCallout } from '@folio/stripes-acq-components';
 
 import '../../../test/jest/__mock__';
 
@@ -23,11 +24,13 @@ describe('useConfiguration', () => {
 
   const mockNamespaceKey = 'test-namespace';
   const mockConfigName = 'general';
+  const mockShowCallout = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     useOkapiKy.mockReturnValue(mockKy);
     useNamespace.mockReturnValue([mockNamespaceKey]);
+    useShowCallout.mockReturnValue(mockShowCallout);
   });
 
   const mockUseQueryWithData = (rawData, isLoading = false) => {
@@ -146,6 +149,51 @@ describe('useConfiguration', () => {
     const { result } = renderHook(() => useConfiguration(mockConfigName));
 
     expect(result.current.isConfigsLoading).toBe(false);
+  });
+
+  it('should disable refetchOnWindowFocus to prevent spurious errors during affiliation switch', () => {
+    mockUseQueryWithData({ configurationSettings: [] }, false);
+
+    renderHook(() => useConfiguration(mockConfigName));
+
+    const callArgs = useQuery.mock.calls[0][0];
+    expect(callArgs.refetchOnWindowFocus).toBe(false);
+  });
+
+  describe('onError callback', () => {
+    beforeEach(() => {
+      mockUseQueryWithData({ configurationSettings: [] }, false);
+      renderHook(() => useConfiguration(mockConfigName));
+    });
+
+    it('should not show callout for AbortError', () => {
+      const { onError } = useQuery.mock.calls[0][0];
+      const abortError = Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' });
+
+      onError(abortError);
+
+      expect(mockShowCallout).not.toHaveBeenCalled();
+    });
+
+    it('should show error callout for non-abort errors', () => {
+      const { onError } = useQuery.mock.calls[0][0];
+
+      onError(new Error('Network error'));
+
+      expect(mockShowCallout).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' })
+      );
+    });
+
+    it('should show error callout when error has no name property', () => {
+      const { onError } = useQuery.mock.calls[0][0];
+
+      onError(null);
+
+      expect(mockShowCallout).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' })
+      );
+    });
   });
 });
 


### PR DESCRIPTION
### Problem

On an ECS environment, when a user switches tenant affiliation while on the **Settings > OAI-PMH** page, in-flight configuration requests are aborted by the browser.

### Solution

Updated the `useConfiguration` hook (`src/settings/hooks/useConfiguration.js`):

- Added `refetchOnWindowFocus: false` to prevent unnecessary refetches that can conflict with affiliation switches.
- Added an `AbortError` guard in `onError` to silently ignore cancelled requests

Refs: [UIOAIPMH-98](https://folio-org.atlassian.net/browse/UIOAIPMH-98)
